### PR TITLE
Remove hardcoded Bazel path from generate-hashes calls

### DIFF
--- a/bazel-diff.axl
+++ b/bazel-diff.axl
@@ -61,7 +61,6 @@ def impl(ctx: TaskContext):
     generate_hashes = bazel_diff([
         "generate-hashes",
         "-w", ctx.std.env.current_dir(),
-        "-b", "/Users/alexeagle/Downloads/bazel-8.4.1-darwin-arm64",
         starting_hashes_json
     ])
     if not generate_hashes.success:
@@ -77,7 +76,6 @@ def impl(ctx: TaskContext):
     generate_hashes = bazel_diff([
         "generate-hashes", 
         "-w", ctx.std.env.current_dir(),
-        "-b", "/Users/alexeagle/Downloads/bazel-8.4.1-darwin-arm64", final_hashes_json
     ])
     if not generate_hashes.success:
         ctx.std.io.stderr.write("Error generating hashes: %s" % generate_hashes.code)


### PR DESCRIPTION
## Summary

- Remove hardcoded `-b /Users/alexeagle/Downloads/bazel-8.4.1-darwin-arm64` flag
  from both `generate-hashes` calls

## Problem

The hardcoded path prevents the extension from working for any other user.

## Solution

Remove the `-b` flag entirely. Per the
[bazel-diff docs](https://github.com/Tinder/bazel-diff#generate-hashes-command),
when `-b` is not specified, bazel-diff will use the Bazel binary available in
PATH.

Addresses: https://github.com/aspect-extensions/impacted/issues/3